### PR TITLE
Add the ability to use a DNSimple User API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A [cert-manager][2] ACME DNS01 solver webhook for [DNSimple][1].
 
 ## Quickstart
 
-Take note of your DNSimple API token from the account settings in the automation tab. Run the following commands replacing the API token placeholders and email address:
+Take note of your DNSimple API token from the account settings in the automation tab. Run the following commands replacing the API token / account ID placeholders and email address:
 
 ```bash
 $ helm repo add neoskop https://charts.neoskop.dev
@@ -18,6 +18,7 @@ $ helm install cert-manager-webhook-dnsimple \
     --namespace cert-manager \
     --dry-run \
     --set dnsimple.token='<DNSIMPLE_API_TOKEN>' \
+    --set dnsimple.accountID='<DNSIMPLE_ACCOUNT_ID>' # Only needed if using a User API token \
     --set clusterIssuer.production.enabled=true \
     --set clusterIssuer.staging.enabled=true \
     --set clusterIssuer.email=email@example.com \
@@ -52,6 +53,7 @@ The Helm chart accepts the following values:
 | name                               | required | description                                     | default value                           |
 | ---------------------------------- | -------- | ----------------------------------------------- | --------------------------------------- |
 | `dnsimple.token`                   | ✔️       | DNSimple API Token                              | _empty_                                 |
+| `dnsimple.accountID`               |          | DNSimple Account ID (required for User tokens)  | _empty_                                 |
 | `clusterIssuer.email`              |          | LetsEncrypt Admin Email                         | `name@example.com`                      |
 | `clusterIssuer.production.enabled` |          | Create a production `ClusterIssuer`             | `false`                                 |
 | `clusterIssuer.staging.enabled`    |          | Create a staging `ClusterIssuer`                | `false`                                 |

--- a/deploy/dnsimple/templates/deployment.yaml
+++ b/deploy/dnsimple/templates/deployment.yaml
@@ -24,14 +24,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "dnsimple-webhook.fullname" . }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.image.pullSecret }}
-          imagePullSecrets:
-            - name: {{ .Values.image.pullSecret }}
-          {{- end }}
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key

--- a/deploy/dnsimple/templates/deployment.yaml
+++ b/deploy/dnsimple/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
-          env:
             - name: DNSIMPLE_ACCOUNT_ID
               value: {{ .Values.dnsimple.accountID | quote }}
           ports:

--- a/deploy/dnsimple/templates/deployment.yaml
+++ b/deploy/dnsimple/templates/deployment.yaml
@@ -41,8 +41,6 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
-            - name: DNSIMPLE_ACCOUNT_ID
-              value: {{ .Values.dnsimple.accountID | quote }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/dnsimple/templates/deployment.yaml
+++ b/deploy/dnsimple/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+          env:
+            - name: DNSIMPLE_ACCOUNT_ID
+              value: {{ .Values.dnsimple.accountID | quote }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/dnsimple/templates/production.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/production.cluster-issuer.yaml
@@ -21,7 +21,7 @@ spec:
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
-            accountID: {{ .Values.dnsimple.accountID }}
+            accountID: {{ .Values.dnsimple.accountID | quote }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/templates/production.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/production.cluster-issuer.yaml
@@ -21,6 +21,7 @@ spec:
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
+            accountID: {{ .Values.dnsimple.accountID }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/templates/staging.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/staging.cluster-issuer.yaml
@@ -21,7 +21,7 @@ spec:
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
-            accountID: {{ .Values.dnsimple.accountID }}
+            accountID: {{ .Values.dnsimple.accountID | quote }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/templates/staging.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/staging.cluster-issuer.yaml
@@ -21,6 +21,7 @@ spec:
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
+            accountID: {{ .Values.dnsimple.accountID }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/values.yaml
+++ b/deploy/dnsimple/values.yaml
@@ -13,7 +13,7 @@ certManager:
 # logLevel: 3
 dnsimple:
   token: ""
-  accountID: ""
+  # accountID:
   # existingTokenSecret: false
   # tokenSecretName:
 clusterIssuer:

--- a/deploy/dnsimple/values.yaml
+++ b/deploy/dnsimple/values.yaml
@@ -13,6 +13,7 @@ certManager:
 # logLevel: 3
 dnsimple:
   token: ""
+  accountID: ""
   # existingTokenSecret: false
   # tokenSecretName:
 clusterIssuer:

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ type dnsimpleDNSProviderConfig struct {
 	// `issuer.spec.acme.dns01.providers.webhook.config` field.
 
 	TokenSecretRef cmmeta.SecretKeySelector `json:"tokenSecretRef"`
+	AccountID      *string                  `json:"accountID"`
 }
 
 // Name is used as the name for this DNS solver when referencing it on the ACME
@@ -86,19 +87,19 @@ func (c *dnsimpleDNSProviderSolver) Name() string {
 	return "dnsimple"
 }
 
-func (c *dnsimpleDNSProviderSolver) getClient(cfg *dnsimpleDNSProviderConfig, namespace string) (*dnsimple.Client, error) {
+func (c *dnsimpleDNSProviderSolver) getClient(cfg *dnsimpleDNSProviderConfig, namespace string) (client *dnsimple.Client, accountID string, err error) {
 	secretName := cfg.TokenSecretRef.LocalObjectReference.Name
 	klog.V(6).Infof("Try to load secret `%s` with key `%s`", secretName, cfg.TokenSecretRef.Key)
 	sec, err := c.client.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to get secret `%s`; %v", secretName, err)
+		return nil, "", fmt.Errorf("unable to get secret `%s`; %v", secretName, err)
 	}
 
 	secBytes, ok := sec.Data[cfg.TokenSecretRef.Key]
 
 	if !ok {
-		return nil, fmt.Errorf("Key %q not found in secret \"%s/%s\"", cfg.TokenSecretRef.Key, cfg.TokenSecretRef.LocalObjectReference.Name, namespace)
+		return nil, "", fmt.Errorf("Key %q not found in secret \"%s/%s\"", cfg.TokenSecretRef.Key, cfg.TokenSecretRef.LocalObjectReference.Name, namespace)
 	}
 
 	apiKey := string(secBytes)
@@ -106,9 +107,27 @@ func (c *dnsimpleDNSProviderSolver) getClient(cfg *dnsimpleDNSProviderConfig, na
 	tc := dnsimple.StaticTokenHTTPClient(context.Background(), apiKey)
 
 	// new client
-	client := dnsimple.NewClient(tc)
+	client = dnsimple.NewClient(tc)
 	client.SetUserAgent("cert-manager-webhook-dnsimple")
-	return client, nil
+
+	// if account id is configured explicitly we use it
+	if cfg.AccountID != nil {
+		return client, *cfg.AccountID, nil
+	}
+
+	// resolve account id if not configured
+	whoamiResponse, err := client.Identity.Whoami(context.Background())
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to lookup account ID: %w", err)
+	}
+
+	// if whoami is called with a user token it does not contain account data
+	if whoamiResponse.Data == nil || whoamiResponse.Data.Account == nil {
+		return nil, "", fmt.Errorf("failed to lookup account ID. data missing. you are most likely using a user token without configuring an account ID in your issuer config.")
+	}
+
+	accountID = strconv.FormatInt(whoamiResponse.Data.Account.ID, 10)
+	return client, accountID, nil
 }
 
 func (c *dnsimpleDNSProviderSolver) getDomainAndEntry(ch *v1alpha1.ChallengeRequest) (string, string) {
@@ -169,19 +188,6 @@ func (c *dnsimpleDNSProviderSolver) deleteRecord(cfg *dnsimpleDNSProviderConfig,
 	return createdRecord.Data, nil
 }
 
-func Whoami(client *dnsimple.Client) (string, error) {
-	whoamiResponse, err := client.Identity.Whoami(context.Background())
-	if err != nil {
-		return "", err
-	}
-
-	if DnsimpleAccountId == "" {
-		return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
-	} else {
-		return DnsimpleAccountId, nil
-	}
-}
-
 // Present is responsible for actually presenting the DNS record with the
 // DNS provider.
 // This method should tolerate being called multiple times with the same value.
@@ -193,15 +199,10 @@ func (c *dnsimpleDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error
 		return err
 	}
 
-	client, err := c.getClient(&cfg, ch.ResourceNamespace)
+	client, accountID, err := c.getClient(&cfg, ch.ResourceNamespace)
 
 	if err != nil {
 		return fmt.Errorf("unable to get client: %s", err)
-	}
-
-	accountID, err := Whoami(client)
-	if err != nil {
-		return fmt.Errorf("unable to fetch account ID: %s", err)
 	}
 
 	entry, domain := c.getDomainAndEntry(ch)
@@ -242,15 +243,10 @@ func (c *dnsimpleDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error
 		return err
 	}
 
-	client, err := c.getClient(&cfg, ch.ResourceNamespace)
+	client, accountID, err := c.getClient(&cfg, ch.ResourceNamespace)
 
 	if err != nil {
 		return fmt.Errorf("unable to get client: %s", err)
-	}
-
-	accountID, err := Whoami(client)
-	if err != nil {
-		return fmt.Errorf("unable to fetch account ID: %s", err)
 	}
 
 	entry, domain := c.getDomainAndEntry(ch)

--- a/main.go
+++ b/main.go
@@ -120,14 +120,9 @@ func (c *dnsimpleDNSProviderSolver) getDomainAndEntry(ch *v1alpha1.ChallengeRequ
 }
 
 func (c *dnsimpleDNSProviderSolver) getExistingRecord(cfg *dnsimpleDNSProviderConfig, client *dnsimple.Client, accountID string, zoneName string, entry string, key string) (*dnsimple.ZoneRecord, error) {
-	zone, err := client.Zones.GetZone(context.Background(), accountID, zoneName)
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to get zone: %s", err)
-	}
 
 	// Look for existing TXT records.
-	records, err := client.Zones.ListRecords(context.Background(), accountID, zone.Data.Name, &dnsimple.ZoneRecordListOptions{Type: dnsimple.String("TXT"), Name: dnsimple.String(entry)})
+	records, err := client.Zones.ListRecords(context.Background(), accountID, zoneName, &dnsimple.ZoneRecordListOptions{Type: dnsimple.String("TXT"), Name: dnsimple.String(entry)})
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to get resource records: %s", err)

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func Whoami(client *dnsimple.Client) (string, error) {
 		return "", err
 	}
 
-	if DnsimpleAccountId != "" {
+	if DnsimpleAccountId == "" {
 		return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
 	} else {
 		return DnsimpleAccountId, nil

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func Whoami(client *dnsimple.Client) (string, error) {
 		return "", err
 	}
 
-	if GroupName != "" {
+	if DnsimpleAccountId != "" {
 		return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
 	} else {
 		return DnsimpleAccountId

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 )
 
 var GroupName = os.Getenv("GROUP_NAME")
-var DnsimpleAccountId = os.Getenv("DNSIMPLE_ACCOUNT_ID")
 
 func main() {
 	if GroupName == "" {

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func Whoami(client *dnsimple.Client) (string, error) {
 	if DnsimpleAccountId != "" {
 		return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
 	} else {
-		return DnsimpleAccountId
+		return DnsimpleAccountId, nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 )
 
 var GroupName = os.Getenv("GROUP_NAME")
+var DnsimpleAccountId = os.Getenv("DNSIMPLE_ACCOUNT_ID")
 
 func main() {
 	if GroupName == "" {
@@ -179,7 +180,11 @@ func Whoami(client *dnsimple.Client) (string, error) {
 		return "", err
 	}
 
-	return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
+	if GroupName != "" {
+		return strconv.FormatInt(whoamiResponse.Data.Account.ID, 10), nil
+	} else {
+		return DnsimpleAccountId
+	}
 }
 
 // Present is responsible for actually presenting the DNS record with the


### PR DESCRIPTION
This _Pull Request_ adds the ability to use a _User_ API token (as opposed to an _Account_ API token) for communicating with the DNSimple API. Currently, if a _User_ API token is attempted to be used, it will fail as discussed in https://github.com/neoskop/cert-manager-webhook-dnsimple/issues/12.

To test, set the `token` value to a valid _User_ DNSimple API token and the `accountID` value to the account ID for the DNSimple account that contains the DNS zones which contain the domains for which Let's Encrypt certificates are to be obtained for.