### PR TITLE
Feature: use unprivileged container port

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ The Helm chart accepts the following values:
 | name                               | required | description                                     | default value                           |
 | ---------------------------------- | -------- | ----------------------------------------------- | --------------------------------------- |
 | `dnsimple.token`                   | ✔️       | DNSimple API Token                              | _empty_                                 |
-| `dnsimple.accountID`               |          | DNSimple Account ID (required when `dnsimple.token` is a user-token)  | _empty_                                 |
-| `clusterIssuer.email`              |          | LetsEncrypt Admin Email                         | _empty_                      |
+| `dnsimple.accountID`               |          | DNSimple Account ID (required when `dnsimple.token` is a user-token)  | _empty_           |
+| `clusterIssuer.email`              |          | LetsEncrypt Admin Email                         | _empty_                                 |
 | `clusterIssuer.production.enabled` |          | Create a production `ClusterIssuer`             | `false`                                 |
 | `clusterIssuer.staging.enabled`    |          | Create a staging `ClusterIssuer`                | `false`                                 |
 | `image.repository`                 | ✔️       | Docker image for the webhook solver             | `ghcr.io/puzzle/cert-manager-webhook-dnsimple` |
-| `image.tag`                        | ✔️       | Docker image tag of the solver                  | latest tagged docker build                                |
+| `image.tag`                        | ✔️       | Docker image tag of the solver                  | latest tagged docker build              |
 | `image.pullPolicy`                 | ✔️       | Image pull policy of the solver                 | `IfNotPresent`                          |
 | `logLevel`                         |          | Set the verbosity of the solver                 | _empty_                                 |
-| `groupName`                        | ✔️       | Identifies the company that created the webhook | _empty_                       |
+| `useUnprivilegedPort`              |          | Use an unprivileged container-port for the webhook  | `true`                              |
+| `groupName`                        | ✔️       | Identifies the company that created the webhook | _empty_                                 |
 | `certManager.namespace`            | ✔️       | The namespace cert-manager was installed to     | `cert-manager`                          |
 | `certManager.serviceAccountName`   | ✔️       | The service account cert-manager runs under     | `cert-manager`                          |
 

--- a/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
@@ -38,12 +38,19 @@ spec:
 {{- if .Values.logLevel }}
             - --v={{ .Values.logLevel }}
 {{- end }}
+{{- if .Values.useUnprivilegedPort }}
+            - --secure-port=8443
+{{- end }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
           ports:
             - name: https
+{{- if .Values.useUnprivilegedPort }}
+              containerPort: 8443
+{{- else }}
               containerPort: 443
+{{- end }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/cert-manager-webhook-dnsimple/values.yaml
+++ b/charts/cert-manager-webhook-dnsimple/values.yaml
@@ -32,6 +32,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 443
+useUnprivilegedPort: true
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Allows the pod expose the webhook on an unpriviliged port, as required by restrictive platforms such as OpenShift.
Fixes https://github.com/puzzle/cert-manager-webhook-dnsimple/issues/19.