### PR TITLE
Change wording and handling of .Values.groupName

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Helm chart accepts the following values:
 | `image.pullPolicy`                 | ✔️       | Image pull policy of the solver                 | `IfNotPresent`                          |
 | `logLevel`                         |          | Set the verbosity of the solver                 | _empty_                                 |
 | `useUnprivilegedPort`              |          | Use an unprivileged container-port for the webhook  | `true`                              |
-| `groupName`                        | ✔️       | Identifies the company that created the webhook | _empty_                                 |
+| `groupName`                        | ✔️       | Name of the API group used to register the webhook API service as | `acme.dnsimple.com`                                 |
 | `certManager.namespace`            | ✔️       | The namespace cert-manager was installed to     | `cert-manager`                          |
 | `certManager.serviceAccountName`   | ✔️       | The service account cert-manager runs under     | `cert-manager`                          |
 

--- a/charts/cert-manager-webhook-dnsimple/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-dnsimple/templates/_helpers.tpl
@@ -7,6 +7,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+APIService group name
+*/}}
+{{- define "dnsimple-webhook.api-group" -}}
+{{- default "acme.dnsimple.com" (.Values.groupName) -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/cert-manager-webhook-dnsimple/templates/apiservice.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/apiservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ $APIRegistrationAPIVersion }}
 kind: APIService
 metadata:
-  name: v1alpha1.{{ .Values.groupName }}
+  name: v1alpha1.{{ include "dnsimple-webhook.api-group" . }}
   labels:
     app: {{ include "dnsimple-webhook.name" . }}
     chart: {{ include "dnsimple-webhook.chart" . }}
@@ -11,7 +11,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "dnsimple-webhook.servingCertificate" . }}"
 spec:
-  group: {{ .Values.groupName }}
+  group: {{ include "dnsimple-webhook.api-group" . }}
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
 {{- end }}
           env:
             - name: GROUP_NAME
-              value: {{ .Values.groupName | quote }}
+              value: {{ include "dnsimple-webhook.api-group" . | quote }}
           ports:
             - name: https
 {{- if .Values.useUnprivilegedPort }}

--- a/charts/cert-manager-webhook-dnsimple/templates/production.cluster-issuer.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/production.cluster-issuer.yaml
@@ -22,6 +22,6 @@ spec:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
             accountID: {{ .Values.dnsimple.accountID | quote }}
-          groupName: {{ .Values.groupName }}
+          groupName: {{ include "dnsimple-webhook.api-group" . }}
           solverName: dnsimple
 {{- end -}}

--- a/charts/cert-manager-webhook-dnsimple/templates/rbac.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/rbac.yaml
@@ -65,7 +65,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups:
-      - {{ .Values.groupName }}
+      - {{ include "dnsimple-webhook.api-group" . }}
     resources:
       - '*'
     verbs:

--- a/charts/cert-manager-webhook-dnsimple/templates/staging.cluster-issuer.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/staging.cluster-issuer.yaml
@@ -22,6 +22,6 @@ spec:
               key: token
               name: {{ include "dnsimple-webhook.tokenSecretName" . }}
             accountID: {{ .Values.dnsimple.accountID | quote }}
-          groupName: {{ .Values.groupName }}
+          groupName: {{ include "dnsimple-webhook.api-group" . }}
           solverName: dnsimple
 {{- end -}}

--- a/charts/cert-manager-webhook-dnsimple/values.yaml
+++ b/charts/cert-manager-webhook-dnsimple/values.yaml
@@ -1,12 +1,8 @@
-# The GroupName here is used to identify your company or business unit that
-# created this webhook.
-# For example, this may be "acme.mycompany.com".
-# This name will need to be referenced in each Issuer's `webhook` stanza to
-# inform cert-manager of where to send ChallengePayload resources in order to
-# solve the DNS01 challenge.
-# This group name should be **unique**, hence using your own company's domain
-# here is recommended.
-groupName: ""
+
+# groupName sets the API group name for the API service that registers this webhook service.
+# If you wish to customize this name, uncomment line and set the value to an FQDN, i.e. acme.company.com
+#groupName: ""
+
 certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager

--- a/charts/cert-manager-webhook-dnsimple/values.yaml
+++ b/charts/cert-manager-webhook-dnsimple/values.yaml
@@ -1,7 +1,7 @@
-
 # groupName sets the API group name for the API service that registers this webhook service.
-# If you wish to customize this name, uncomment line and set the value to an FQDN, i.e. acme.company.com
-#groupName: ""
+# It will be used when specifying an issuer for a (Cluster)Issuer object.
+# When customizing, provide an FQDN, for example acme.my-company.com.
+groupName: "acme.dnsimple.com"
 
 certManager:
   namespace: cert-manager


### PR DESCRIPTION
Adds:
- An actual default value for `groupName`

Changes:
- Wording regarding `groupName` in README and `values.yaml` 

Addresses https://github.com/puzzle/cert-manager-webhook-dnsimple/issues/18