### PR TITLE
Automatic patch releases

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      # fetch-tags: true is broken
+      - name: Fetch all tags
+        run: git fetch --depth=1 --tags
 
       - name: Get new versions
         id: new-versions
@@ -112,7 +116,7 @@ jobs:
 
           CHART_VERSION=$(bump_patch $(cat charts/cert-manager-webhook-dnsimple/Chart.yaml | grep "version:" | awk '{print $2}'))
           APP_VERSION=$(echo "v$(bump_patch $(cat charts/cert-manager-webhook-dnsimple/Chart.yaml | grep 'appVersion:' | awk '{print $2}'))")
-          TAG=$(echo "v$(bump_patch $(git describe --tags --abbrev=0 --match 'v*'))")
+          TAG=$(echo "v$(bump_patch $(git tag -l 'v*' --sort=committerdate | tail -n 1))")
 
           echo -e "New app version: $APP_VERSION\nNew chart version: $CHART_VERSION\nNew tag: $TAG"
 
@@ -172,6 +176,7 @@ jobs:
 #    with:
 #      release-body-addendum: "Automated release"
 
+  # Only notify on success or failure
   notify:
     needs:
       - update

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -121,11 +121,59 @@ jobs:
           git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
           git tag
-        #git push origin "${{ steps.new-versions.outputs.tag }}"
+#      #git push origin "${{ steps.new-versions.outputs.tag }}"
+#
+#      - name: Await docker build
+#        id: docker-build
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        run: |          
+#          echo "Waiting for release workflow to complete..."
+#
+#          # ID can be derived using 'gh workflow list'
+#          # The ID below is of the "Build tagged Docker image" workflow
+#          WORKFLOW_ID=99918803
+#
+#          for i in {1..30}; do
+#            RUN_DETAILS=$(gh run list --workflow="$WORKFLOW_ID" --branch="${{ steps.new-versions.outputs.tag }}" --json --json conclusion,status,url,databaseId)
+#            if [ $(echo $RUN_DETAILS | jq length) -gt 0 ]; then
+#              RUN_ID=$(echo $RUN_DETAILS | jq -r .[0].databaseId)
+#              STATUS=$(gh run view "$RUN_ID" --json conclusion --jq .conclusion)
+#              if [ "$STATUS" = "success" ]; then
+#                echo "Docker build workflow has concluded"
+#                exit 0
+#              elif [ "$STATUS" = "failure" ]; then
+#                echo "::error title=Docker build failed::Docker build action has failed"
+#                exit 1
+#              fi
+#            fi
+#            sleep 10
+#          done
+#
+#          echo "::error title=Docker build timed out::Timed out awaiting docker build action"
+#          exit 1
   
 #  trigger-release:
-#    needs: check-and-release
-#    if: ${{ needs.check-and-release.outputs.check-prs.has_changes == 'true' }}
+#    needs: update
+#    if: ${{ needs.update.check-prs.has_changes == 'true' }}
 #    uses: .github/workflows/helm-release.yaml
 #    with:
 #      release-body-addendum: "Automated release"
+
+  notify:
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify status
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
+        if gh run view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "update") | .conclusion' | grep -q "success"; then
+          MSG=":white_check_mark: Automated patch release completed successfully!\nChart version: ${}"
+        else
+          MSG=":x: Automated patch release failed. Please [check the logs]($THIS_RUN)."
+        fi
+        
+        BODY=$(cat .github/workflows/rk_body.json | jq ".text = \"$MSG\"")
+        curl -X POST -H 'Content-Type: application/json' --data "$BODY" ${{ secrets.RK_WEBHOOK_URL }}

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -141,7 +141,7 @@ jobs:
           git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
           git tag
-          #git push origin "${{ steps.new-versions.outputs.tag }}"
+          git push origin "${{ steps.new-versions.outputs.tag }}"
 
       - name: Await docker build
         id: docker-build
@@ -149,6 +149,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |          
           echo "Waiting for release workflow to complete..."
+          sleep 5
 
           # ID can be derived using 'gh workflow list'
           # The ID below is of the "Build tagged Docker image" workflow

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -4,9 +4,6 @@ on:
   #schedule:
   #  - cron: '0 0 1 * *'
   workflow_dispatch:
-  push:
-    branches:
-      - change/releases
 
 jobs:
   check:
@@ -30,7 +27,7 @@ jobs:
           echo "Latest release $(echo "$RELEASE" | jq .name) was published at $CREATED_AT, $DAYS_DIFF days ago."
           echo "skip=$([ $DAYS_DIFF -lt 30 ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
 
-      # Any PR since last release that is not authored by renovate and does NOT have a "patch" label will cause this run to be skipped.
+      # Any PR since last month that is not authored by renovate and does NOT have a "patch" label will cause this run to be skipped.
       # Renovate automerges minor changes as well, but we consider such as patches as it's only affects packages.
       - name: Check for merged PRs since last release
         id: check-prs

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check-prs.outputs.has_changes }}
+      non_patch_prs: ${{ steps.check-prs.outputs.non_patch_prs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,6 +87,10 @@ jobs:
     needs: check
     if: ${{ needs.check.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.new-versions.outputs.chart }}
+      app: ${{ steps.new-versions.outputs.app }}
+      tag: ${{ steps.new-versions.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -166,8 +173,10 @@ jobs:
 #      release-body-addendum: "Automated release"
 
   notify:
-    needs: update
-    if: always()
+    needs:
+      - update
+      - check
+    if: ${{ always() && needs.check.outputs.non_patch_prs != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -163,7 +163,7 @@ jobs:
 
   notify:
     needs: check
-    if: $${{ always() && !needs.check.outputs.non_patch_prs }}
+    if: $${{ always() && needs.check.outputs.non_patch_prs != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -62,6 +62,7 @@ jobs:
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
 
       - name: Notify if bad
+        id: notify-abort
         if: ${{ steps.check-prs.outputs.has_changes == 'false' && steps.check-prs.outputs.non_patch_prs == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -161,9 +162,12 @@ jobs:
 #      release-body-addendum: "Automated release"
 
   notify:
-    if: always()
+    needs: check
+    if: $${{ always() && !needs.check.outputs.non_patch_prs }}
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+    
     - name: Notify status
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -145,7 +145,7 @@ jobs:
 
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git add charts/cert-manager-webhook-dnsimple/Chart.yaml
+          git add -u
 
           git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -50,7 +50,7 @@ jobs:
           if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
             FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
             FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
-            if [ "$FILTERED_PRS_AMOUNT" -gt 9 ]; then
+            if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
               echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
               

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -47,7 +47,7 @@ jobs:
           if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
             FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
             FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
-            if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
+            if [ "$FILTERED_PRS_AMOUNT" -gt 9 ]; then
               echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
               echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -113,8 +113,9 @@ jobs:
       - name: Update versions
         id: update-versions
         run: |
-          cat charts/cert-manager-webhook-dnsimple/Chart.yaml | sed 's|appVersion:.*|appVersion: "${{ steps.new-versions.outputs.app }}"|'
-          cat charts/cert-manager-webhook-dnsimple/Chart.yaml | sed 's|version:.*|version: ${{ steps.new-versions.outputs.chart }}|'
+          sed -i 's|^appVersion:.*|appVersion: "${{ steps.new-versions.outputs.app }}"|' charts/cert-manager-webhook-dnsimple/Chart.yaml
+          sed -i 's|^version:.*|version: ${{ steps.new-versions.outputs.chart }}|' charts/cert-manager-webhook-dnsimple/Chart.yaml
+          cat charts/cert-manager-webhook-dnsimple/Chart.yaml
 
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -92,8 +92,17 @@ jobs:
       app: ${{ steps.new-versions.outputs.app }}
       tag: ${{ steps.new-versions.outputs.tag }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_SECRET }}
+  
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
       
       # fetch-tags: true is broken
       - name: Fetch all tags
@@ -140,7 +149,10 @@ jobs:
 
           git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
+
+          echo "Git tags AFTER creating our own (${{ steps.new-versions.outputs.tag }})"
           git tag
+          
           git push origin "${{ steps.new-versions.outputs.tag }}"
 
       - name: Await docker build

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -41,7 +41,7 @@ jobs:
           if [ "$LAST_RELEASE" = "none" ]; then
             MERGED_PRS=$(gh pr list --state merged --limit 1 --json number)
           else
-            MERGED_PRS=$(gh pr list --state merged --base ${{ github.event.repository.default_branch }} --search "merged:>=$(git log -1 --format=%aI $LAST_RELEASE | cut -d'T' -f1)" --json --json author,title,labels,number)
+            MERGED_PRS=$(gh pr list --state merged --base ${{ github.event.repository.default_branch }} --search "merged:>=$(git log -1 --format=%aI $LAST_RELEASE | cut -d'T' -f1)" --json author,title,labels,number)
           fi
 
           if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
@@ -57,7 +57,7 @@ jobs:
             
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             exit 0
-          else
+          fi
             
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -50,15 +50,18 @@ jobs:
             if [ "$FILTERED_PRS_AMOUNT" -gt 9 ]; then
               echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
+              
               echo "has_changes=false" >> "$GITHUB_OUTPUT"
               echo "non_patch_prs=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             
+            echo "Has changes"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-            
+          
+          echo "Has no changes"
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
 
       - name: Notify if bad

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -127,17 +127,21 @@ jobs:
       - name: Update versions
         id: update-versions
         run: |
-          sed -i 's|^appVersion:.*|appVersion: "${{ steps.new-versions.outputs.app }}"|' charts/cert-manager-webhook-dnsimple/Chart.yaml
-          sed -i 's|^version:.*|version: ${{ steps.new-versions.outputs.chart }}|' charts/cert-manager-webhook-dnsimple/Chart.yaml
-          cat charts/cert-manager-webhook-dnsimple/Chart.yaml
+          export TERM=xterm-color
+          yq e '.appVersion = "${{ steps.new-versions.outputs.app }}"' -i charts/cert-manager-webhook-dnsimple/Chart.yaml
+          yq e '.version = "${{ steps.new-versions.outputs.chart }}"' -i charts/cert-manager-webhook-dnsimple/Chart.yaml
+          yq e '.image.tag = "${{ steps.new-versions.outputs.tag }}"' -i charts/cert-manager-webhook-dnsimple/values.yaml
+
+          git diff
 
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git add charts/cert-manager-webhook-dnsimple/Chart.yaml
+
           git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
           git tag
-#      #git push origin "${{ steps.new-versions.outputs.tag }}"
+          #git push origin "${{ steps.new-versions.outputs.tag }}"
 #
 #      - name: Await docker build
 #        id: docker-build

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -153,7 +153,7 @@ jobs:
           echo "Git tags AFTER creating our own (${{ steps.new-versions.outputs.tag }})"
           git tag
           
-          git push origin "${{ steps.new-versions.outputs.tag }}"
+          git push && git push origin "${{ steps.new-versions.outputs.tag }}"
 
       - name: Await docker build
         id: docker-build

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,8 +1,8 @@
 name: Automated patch release
 
 on:
-  #schedule:
-  #  - cron: '0 0 1 * *'
+  schedule:
+    - cron: '0 12 1 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -142,43 +142,44 @@ jobs:
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
           git tag
           #git push origin "${{ steps.new-versions.outputs.tag }}"
-#
-#      - name: Await docker build
-#        id: docker-build
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        run: |          
-#          echo "Waiting for release workflow to complete..."
-#
-#          # ID can be derived using 'gh workflow list'
-#          # The ID below is of the "Build tagged Docker image" workflow
-#          WORKFLOW_ID=99918803
-#
-#          for i in {1..30}; do
-#            RUN_DETAILS=$(gh run list --workflow="$WORKFLOW_ID" --branch="${{ steps.new-versions.outputs.tag }}" --json --json conclusion,status,url,databaseId)
-#            if [ $(echo $RUN_DETAILS | jq length) -gt 0 ]; then
-#              RUN_ID=$(echo $RUN_DETAILS | jq -r .[0].databaseId)
-#              STATUS=$(gh run view "$RUN_ID" --json conclusion --jq .conclusion)
-#              if [ "$STATUS" = "success" ]; then
-#                echo "Docker build workflow has concluded"
-#                exit 0
-#              elif [ "$STATUS" = "failure" ]; then
-#                echo "::error title=Docker build failed::Docker build action has failed"
-#                exit 1
-#              fi
-#            fi
-#            sleep 10
-#          done
-#
-#          echo "::error title=Docker build timed out::Timed out awaiting docker build action"
-#          exit 1
+
+      - name: Await docker build
+        id: docker-build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |          
+          echo "Waiting for release workflow to complete..."
+
+          # ID can be derived using 'gh workflow list'
+          # The ID below is of the "Build tagged Docker image" workflow
+          WORKFLOW_ID=99918806
+          RUN_DETAILS=$(gh run list --workflow="$WORKFLOW_ID" --branch="${{ steps.new-versions.outputs.tag }}" --json conclusion,status,url,databaseId)
+          echo $RUN_DETAILS | jq -r .[0].url
+
+          for i in {1..30}; do
+            RUN_DETAILS=$(gh run list --workflow="$WORKFLOW_ID" --branch="${{ steps.new-versions.outputs.tag }}" --json conclusion,status,url,databaseId)
+            if [ $(echo $RUN_DETAILS | jq length) -gt 0 ]; then
+              RUN_ID=$(echo $RUN_DETAILS | jq -r .[0].databaseId)
+              STATUS=$(gh run view "$RUN_ID" --json conclusion --jq .conclusion)
+              if [ "$STATUS" = "success" ]; then
+                echo "Docker build workflow has concluded"
+                exit 0
+              elif [ "$STATUS" = "failure" ]; then
+                echo "::error title=Docker build failed::Docker build action has failed"
+                exit 1
+              fi
+            fi
+            sleep 10
+          done
+
+          echo "::error title=Docker build timed out::Timed out awaiting docker build action"
+          exit 1
   
-#  trigger-release:
-#    needs: update
-#    if: ${{ needs.update.check-prs.has_changes == 'true' }}
-#    uses: .github/workflows/helm-release.yaml
-#    with:
-#      release-body-addendum: "Automated release"
+  trigger-release:
+    needs: update
+    uses: .github/workflows/helm-release.yaml
+    with:
+      release-body-addendum: "Automated release"
 
   # Only notify on success or failure
   notify:
@@ -195,10 +196,13 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
-        CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "update") | .conclusion')
-        echo "Update job conclusion: $CONCLUSION"
         
-        if [ "$CONCLUSION" == "success" ]; then
+        CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "update") | .conclusion')
+        TRIGGER_CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "trigger-release") | .conclusion')
+        echo "Update job conclusion: $CONCLUSION"
+        echo "Trigger-release job conclusion: $TRIGGER_CONCLUSION"
+        
+        if [ "$CONCLUSION" == "success" -a "$TRIGGER_CONCLUSION" == "success" ]; then
           MSG=$(cat <<EOF
         :white_check_mark: Automated patch release completed successfully!
         New chart version: ${{ needs.update.outputs.chart }}
@@ -206,8 +210,11 @@ jobs:
         New tag: ${{ needs.update.outputs.tag }}
         EOF
         )
-        elif [ "$CONCLUSION" == "failure" ]; then
+
+        elif [ "$CONCLUSION" == "failure" -o "$TRIGGER_CONCLUSION" == "failure" ]; then
           MSG=":x: Automated patch release failed. Please [check the logs]($THIS_RUN)."
+        else
+          MSG=":warning: Automated patch release possibly failed! Please [check the logs]($THIS_RUN)."
         fi
         
         if [ -n "$MSG" ]; then

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -177,7 +177,7 @@ jobs:
   
   trigger-release:
     needs: update
-    uses: .github/workflows/helm-release.yaml
+    uses: ./.github/workflows/helm-release.yaml
     with:
       release-body-addendum: "Automated release"
 

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -162,8 +162,8 @@ jobs:
 #      release-body-addendum: "Automated release"
 
   notify:
-    needs: check
-    if: $${{ always() && needs.check.outputs.non_patch_prs != 'true' }}
+    needs: update
+    if: always()
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -173,11 +173,22 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
-        if gh run view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "update") | .conclusion' | grep -q "success"; then
-          MSG=":white_check_mark: Automated patch release completed successfully!\nChart version: ${}"
-        else
+        CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "update") | .conclusion')
+        echo "Update job conclusion: $CONCLUSION"
+        
+        if [ "$CONCLUSION" == "success" ]; then
+          MSG=$(cat <<EOF
+        :white_check_mark: Automated patch release completed successfully!
+        New chart version: ${{ needs.update.outputs.chart }}
+        New app version: ${{ needs.update.outputs.app }}
+        New tag: ${{ needs.update.outputs.tag }}
+        EOF
+        )
+        elif [ "$CONCLUSION" == "failure" ]; then
           MSG=":x: Automated patch release failed. Please [check the logs]($THIS_RUN)."
         fi
         
-        BODY=$(cat .github/workflows/rk_body.json | jq ".text = \"$MSG\"")
-        curl -X POST -H 'Content-Type: application/json' --data "$BODY" ${{ secrets.RK_WEBHOOK_URL }}
+        if [ -n "$MSG" ]; then
+          BODY=$(cat .github/workflows/rk_body.json | jq ".text = \"$MSG\"")
+          curl -X POST -H 'Content-Type: application/json' --data "$BODY" ${{ secrets.RK_WEBHOOK_URL }}
+        fi

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -48,7 +48,7 @@ jobs:
             FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
             FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
             if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
-              echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT that are possibly not patch releases have been found"
+              echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
               echo "has_changes=false" >> "$GITHUB_OUTPUT"
               echo "non_patch_prs=true" >> "$GITHUB_OUTPUT"
@@ -69,7 +69,7 @@ jobs:
           THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
           MSG=$(cat <<EOF
           :warning: Did not create an automated patch release because it could contain PRs with changes more impactful than just a patch.
-          [Check the logs of the latest run]($THIS_RUN) please and manually create a release after review :isforme:
+          [Check the logs of the latest run](${THIS_RUN}#step:4:1) please and manually create a release after review :isforme:
           EOF
           )
           

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -50,7 +50,7 @@ jobs:
           if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
             FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
             FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
-            if [ "$FILTERED_PRS_AMOUNT" -gt 9 ]; then
+            if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
               echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
               
@@ -182,7 +182,7 @@ jobs:
                 exit 1
               fi
             fi
-            sleep 10
+            sleep 20
           done
 
           echo "::error title=Docker build timed out::Timed out awaiting docker build action"
@@ -211,7 +211,7 @@ jobs:
         THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
         
         CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "update") | .conclusion')
-        TRIGGER_CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name == "trigger-release") | .conclusion')
+        TRIGGER_CONCLUSION=$(gh run view ${{ github.run_id }} --json jobs | jq -r '.jobs[] | select(.name | startswith("trigger-release")) | .conclusion')
         echo "Update job conclusion: $CONCLUSION"
         echo "Trigger-release job conclusion: $TRIGGER_CONCLUSION"
         

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -147,7 +147,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add -u
 
-          git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
+          git commit -m "chore: Update versions for chart release ${{ steps.new-versions.outputs.chart }}"
           git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
 
           echo "Git tags AFTER creating our own (${{ steps.new-versions.outputs.tag }})"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -50,7 +50,7 @@ jobs:
           if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
             FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
             FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
-            if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
+            if [ "$FILTERED_PRS_AMOUNT" -gt 9 ]; then
               echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT PRs that are possibly not patch releases have been found"
               echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
               

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -17,6 +17,8 @@ jobs:
       # We only continue if the last release was actually a month ago
       - name: Check age of last release
         id: check-age
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           RELEASE=$(gh release view --json name,createdAt)
           CREATED_AT=$(echo "$RELEASE" | jq -r .createdAt)
@@ -32,6 +34,8 @@ jobs:
       - name: Check for merged PRs since last release
         id: check-prs
         if: ${{ steps.check-age.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           LAST_RELEASE=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
           if [ "$LAST_RELEASE" = "none" ]; then
@@ -56,8 +60,6 @@ jobs:
           else
             
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify if bad
         if: ${{ steps.check-prs.outputs.has_changes == 'false' && steps.check-prs.outputs.non_patch_prs == 'true' }}

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,129 @@
+name: Automated patch release
+
+on:
+  #schedule:
+  #  - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # We only continue if the last release was actually a month ago
+      - name: Check age of last release
+        id: check-age
+        run: |
+          RELEASE=$(gh release view --json name,createdAt)
+          CREATED_AT=$(echo "$RELEASE" | jq -r .createdAt)
+          CREATED_TIMESTAMP=$(date -d "$CREATED_AT" +%s)
+          CURRENT_TIMESTAMP=$(date +%s)
+          DAYS_DIFF=$(( ($CURRENT_TIMESTAMP - $CREATED_TIMESTAMP) / 86400 ))
+
+          echo "Latest release $(echo "$RELEASE" | jq .name) was published at $CREATED_AT, $DAYS_DIFF days ago."
+          echo "skip=$([ $DAYS_DIFF -lt 30 ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
+
+      # Any PR since last month that is not authored by renovate and does NOT have a "patch" label will cause this run to be skipped.
+      # Renovate automerges minor changes as well, but we consider such as patches as it's only affects packages.
+      - name: Check for merged PRs since last release
+        id: check-prs
+        if: ${{ steps.check-age.outputs.skip != 'true' }}
+        run: |
+          LAST_RELEASE=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          if [ "$LAST_RELEASE" = "none" ]; then
+            MERGED_PRS=$(gh pr list --state merged --limit 1 --json number)
+          else
+            MERGED_PRS=$(gh pr list --state merged --base ${{ github.event.repository.default_branch }} --search "merged:>=$(git log -1 --format=%aI $LAST_RELEASE | cut -d'T' -f1)" --json --json author,title,labels,number)
+          fi
+
+          if [ "$(echo $MERGED_PRS | jq '. | length')" -gt 0 ]; then
+            FILTERED_PRS=$(echo "$MERGED_PRS" | jq '[.[] | select(.author.login != "app/renovate") | select((.labels | length < 1) or (.labels | all(.name != "patch")))]')
+            FILTERED_PRS_AMOUNT=$(echo $FILTERED_PRS | jq length)
+            if [ "$FILTERED_PRS_AMOUNT" -gt 0 ]; then
+              echo "::warning title=Non-patch PRs found::A total of $FILTERED_PRS_AMOUNT that are possibly not patch releases have been found"
+              echo $FILTERED_PRS | jq '.[] | {title: .title, author: "\(.author.login) (\(.author.name))", url: "https://github.com/puzzle/cert-manager-webhook-dnsimple/pull/\(.number)", number: .number}'
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "non_patch_prs=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify if bad
+        if: ${{ steps.check-prs.outputs.has_changes == 'false' && steps.check-prs.outputs.non_patch_prs == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          THIS_RUN=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[] | select(.name == "${{ github.job }}") | .url')
+          MSG=$(cat <<EOF
+          :warning: Did not create an automated patch release because it could contain PRs with changes more impactful than just a patch.
+          [Check the logs of the latest run]($THIS_RUN) please and manually create a release after review :isforme:
+          EOF
+          )
+          
+          BODY=$(cat .github/workflows/rk_body.json | jq ".text = \"$MSG\"")
+          curl -X POST -H 'Content-Type: application/json' --data "$BODY" ${{ secrets.RK_WEBHOOK_URL }}
+
+  update:
+    needs: check
+    if: ${{ needs.check.outputs.has_changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get new versions
+        id: new-versions
+        run: |
+          bump_patch() {
+            clean=$(echo "$1" | sed 's|[v\"]||g')
+
+            major=$(echo "$clean" | cut -d. -f1)
+            minor=$(echo "$clean" | cut -d. -f2)
+            patch=$(echo "$clean" | cut -d. -f3)
+
+            patch=$((patch + 1))
+
+            echo "$major.$minor.$patch"
+          }
+
+          CHART_VERSION=$(bump_patch $(cat charts/cert-manager-webhook-dnsimple/Chart.yaml | grep "version:" | awk '{print $2}'))
+          APP_VERSION=$(echo "v$(bump_patch $(cat charts/cert-manager-webhook-dnsimple/Chart.yaml | grep 'appVersion:' | awk '{print $2}'))")
+          TAG=$(echo "v$(bump_patch $(git describe --tags --abbrev=0 --match 'v*'))")
+
+          echo -e "New app version: $APP_VERSION\nNew chart version: $CHART_VERSION\nNew tag: $TAG"
+
+          echo "chart=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          echo "app=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Update versions
+        id: update-versions
+        run: |
+          cat charts/cert-manager-webhook-dnsimple/Chart.yaml | sed 's|appVersion:.*|appVersion: "${{ steps.new-versions.outputs.app }}"|'
+          cat charts/cert-manager-webhook-dnsimple/Chart.yaml | sed 's|version:.*|version: ${{ steps.new-versions.outputs.chart }}|'
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add charts/cert-manager-webhook-dnsimple/Chart.yaml
+          git commit -m "chore: Update versions for release ${{ steps.new-versions.outputs.tag }}"
+          git tag -a "${{ steps.new-versions.outputs.tag }}" -m "Release ${{ steps.new-versions.outputs.tag }}"
+          git tag
+        #git push origin "${{ steps.new-versions.outputs.tag }}"
+  
+#  trigger-release:
+#    needs: check-and-release
+#    if: ${{ needs.check-and-release.outputs.check-prs.has_changes == 'true' }}
+#    uses: .github/workflows/helm-release.yaml
+#    with:
+#      release-body-addendum: "Automated release"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -4,6 +4,9 @@ on:
   #schedule:
   #  - cron: '0 0 1 * *'
   workflow_dispatch:
+  push:
+    branches:
+      - change/releases
 
 jobs:
   check:
@@ -27,7 +30,7 @@ jobs:
           echo "Latest release $(echo "$RELEASE" | jq .name) was published at $CREATED_AT, $DAYS_DIFF days ago."
           echo "skip=$([ $DAYS_DIFF -lt 30 ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
 
-      # Any PR since last month that is not authored by renovate and does NOT have a "patch" label will cause this run to be skipped.
+      # Any PR since last release that is not authored by renovate and does NOT have a "patch" label will cause this run to be skipped.
       # Renovate automerges minor changes as well, but we consider such as patches as it's only affects packages.
       - name: Check for merged PRs since last release
         id: check-prs

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,6 +4,11 @@ name: Release a new chart version
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release-body-addendum:
+        type: string
+        required: false
 
 jobs:
   release:
@@ -40,6 +45,11 @@ jobs:
           
           # Workaround to get newlines working
           echo -e "### Changes since \`${LAST_TAG}\`\n\n${COMMITS}" > msg
+
+          if [[ -n "${{ inputs.release-body-addendum }}" ]]; then
+            echo -e "\n${{ inputs.release-body-addendum }}" >> msg
+          fi
+
           gh release edit ${CURRENT_TAG} --notes "$(cat msg)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
         # fetch-tags: true - from experience, this usually results in errors
         # > Also see: https://github.com/actions/checkout/issues/1467
 

--- a/.github/workflows/rk_body.json
+++ b/.github/workflows/rk_body.json
@@ -1,0 +1,5 @@
+{
+  "avatar": "https://github.githubassets.com/images/icons/emoji/shipit.png",
+  "username": "cert-manager-webhook-dnsimple",
+  "text": "This message should be different"
+}


### PR DESCRIPTION
This PR enables automatic patch releases, triggered on a schedule (once a month).  
The following conditions for an automatic patch release must be met (at time of workflow run):
- Last release is older than 30 days
- Only PRs authored by `renovate` or PRs labeled with `patch` have been merged since the last release

The workflow automatically increments the chart version, app version and repo tags, therefore also the docker tag.  
