### PR TITLE
Add Restricted-compatible security contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The Helm chart accepts the following values:
 | `image.pullPolicy`                 | ✔️       | Image pull policy of the solver                 | `IfNotPresent`                          |
 | `logLevel`                         |          | Set the verbosity of the solver                 | _empty_                                 |
 | `useUnprivilegedPort`              |          | Use an unprivileged container-port for the webhook  | `true`                              |
+| `podSecurityContext`               |          | Pod security context; defaults to UID 65532 with `RuntimeDefault` seccomp | see `values.yaml` |
+| `securityContext`                  |          | Webhook container security context; defaults to no privilege escalation and all capabilities dropped | see `values.yaml` |
 | `groupName`                        | ✔️       | Name of the API group used to register the webhook API service as | `acme.dnsimple.com`                                 |
 | `certManager.namespace`            | ✔️       | The namespace cert-manager was installed to     | `cert-manager`                          |
 | `certManager.serviceAccountName`   | ✔️       | The service account cert-manager runs under     | `cert-manager`                          |

--- a/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-dnsimple/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "dnsimple-webhook.fullname" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
@@ -33,6 +37,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key

--- a/charts/cert-manager-webhook-dnsimple/values.yaml
+++ b/charts/cert-manager-webhook-dnsimple/values.yaml
@@ -30,6 +30,16 @@ service:
   portName: https
 useUnprivilegedPort: true
 replicaCount: 1
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary

- expose pod and container security-context values in the Helm chart
- default the webhook pod to UID 65532 with RuntimeDefault seccomp
- default the container to disallow privilege escalation and drop all Linux capabilities
- document both new chart values

## Rationale

The webhook already supports the unprivileged 8443 listener. These defaults make that deployment satisfy Kubernetes Pod Security Restricted while preserving the image's existing non-root UID. Both maps remain configurable, and setting either value to null omits that security context for installations with a different runtime contract.

## Files changed

- README.md: documents podSecurityContext and securityContext
- charts/cert-manager-webhook-dnsimple/values.yaml: adds Restricted-compatible defaults
- charts/cert-manager-webhook-dnsimple/templates/deployment.yaml: renders both maps

## Validation

- helm lint
- default and null-override helm template renders
- kubeconform strict: 10 valid, 0 invalid/errors, 4 custom-resource schemas skipped
- Kyverno CLI 1.18.2 Pod Security Restricted evaluation: 1 pass, 0 fail/warn/error
- Kubernetes 1.36 server-side dry-run of the full rendered chart
- git diff --check

No DNSimple credentials or Kubernetes Secret contents were accessed or changed while preparing this contribution. A chart version bump is intentionally left to the repository's release workflow.
